### PR TITLE
Add customer notification option

### DIFF
--- a/Model/EmailNotifier.php
+++ b/Model/EmailNotifier.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageCondition\ChangeCustomerPassword\Model;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Store\Model\StoreManagerInterface;
+
+class EmailNotifier
+{
+    public function __construct(
+        protected TransportBuilder $transportBuilder,
+        protected StoreManagerInterface $storeManager,
+        protected CustomerRepositoryInterface $customerRepository,
+        protected string $templateId = 'magecondition_change_customer_password',
+        protected string $sender = 'general'
+    ) {
+    }
+
+    public function notify(int $customerId, string $newPassword): void
+    {
+        $customer = $this->customerRepository->getById($customerId);
+        $storeId = (int) $this->storeManager->getStore()->getId();
+
+        $transport = $this->transportBuilder
+            ->setTemplateIdentifier($this->templateId)
+            ->setTemplateOptions(['area' => Area::AREA_FRONTEND, 'store' => $storeId])
+            ->setTemplateVars(['customer' => $customer, 'newPassword' => $newPassword])
+            ->setFromByScope($this->sender, $storeId)
+            ->addTo($customer->getEmail(), $customer->getFirstname() . ' ' . $customer->getLastname())
+            ->getTransport();
+
+        $transport->sendMessage();
+    }
+}

--- a/Observer/ChangePassword.php
+++ b/Observer/ChangePassword.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MageCondition\ChangeCustomerPassword\Observer;
 
+use MageCondition\ChangeCustomerPassword\Model\EmailNotifier;
 use MageCondition\ChangeCustomerPassword\Model\PasswordManager;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
@@ -11,8 +12,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 class ChangePassword implements ObserverInterface
 {
-    public function __construct(protected PasswordManager $passwordManager)
-    {
+    public function __construct(
+        protected PasswordManager $passwordManager,
+        protected EmailNotifier $emailNotifier
+    ) {
     }
 
     /**
@@ -26,6 +29,10 @@ class ChangePassword implements ObserverInterface
         $changePassword = $observer->getEvent()->getRequest()->getPost('change_password');
         if ($changePassword['new_password']) {
             $this->passwordManager->setNewPassword((int) $customer->getId(), $changePassword['new_password']);
+
+            if (!empty($changePassword['notify_customer'])) {
+                $this->emailNotifier->notify((int) $customer->getId(), $changePassword['new_password']);
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Simple and intuitive interface for ease of use.
 - Lightweight and minimal impact on system performance.
 - ACL (Access Control List) capabilities to enable or disable functionality for admin users.
+- Optionally notify customers about their new password via email.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.0"
     },
     "type": "magento2-module",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "authors": [
         {
             "name": "Oleksandr",

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Mail/etc/email_templates.xsd">
+    <template id="magecondition_change_customer_password" label="Notify Customer About New Password" file="notify_customer.html" type="html" module="MageCondition_ChangeCustomerPassword" area="frontend"/>
+</config>

--- a/view/base/ui_component/customer_form.xml
+++ b/view/base/ui_component/customer_form.xml
@@ -15,5 +15,22 @@
                 <label>New Password</label>
             </settings>
         </field>
+        <field name="notify_customer" sortOrder="10" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">customer</item>
+                    <item name="default" xsi:type="boolean">false</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Notify Customer</label>
+                <notice translate="true">send new password to the customer via email</notice>
+                <valueMap>
+                    <map name="true" value="1"/>
+                    <map name="false" value="0"/>
+                </valueMap>
+            </settings>
+        </field>
     </fieldset>
 </form>

--- a/view/frontend/email/notify_customer.html
+++ b/view/frontend/email/notify_customer.html
@@ -1,0 +1,4 @@
+<p>Hello {{var customer.getFirstname()}} {{var customer.getLastname()}},</p>
+<p>Your password has been updated by an administrator. Your new password is:</p>
+<p><strong>{{var newPassword}}</strong></p>
+<p>Regards,<br/>{{trans 'Administration'}}</p>


### PR DESCRIPTION
## Summary
- add checkbox to notify customer when changing password
- send email with new password if checkbox is selected
- register email template
- bump version to 1.0.3

## Testing
- `php -l Observer/ChangePassword.php`
- `php -l Model/EmailNotifier.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_6888b3e9c9f08332b540001e6423eb40